### PR TITLE
fix: invitees method returns correct data

### DIFF
--- a/app/models/viewing_party.rb
+++ b/app/models/viewing_party.rb
@@ -3,6 +3,7 @@ class ViewingParty < ApplicationRecord
   has_many :users, through: :viewing_party_users
 
   def invitees
-    viewing_party_users.where(host: false).pluck(:id)
+    viewing_party_users.joins(:user).where(host: false).pluck('users.id', 'users.name', 'users.username')
+    # require 'pry'; binding.pry
   end
 end


### PR DESCRIPTION
This alters active record language, fixing json object returned in creating a viewing party request